### PR TITLE
Updates to compile with ghc 8.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+/.stack-work
+/stack.yaml

--- a/Autobahn.cabal
+++ b/Autobahn.cabal
@@ -7,7 +7,7 @@ name:                Autobahn
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.1.0.0
+version:             0.2.0.0
 
 -- A short (one-line) description of the package.
 synopsis: A tool for inferring strictness annotations in Haskell programs.
@@ -49,10 +49,28 @@ executable Autobahn
   
   -- LANGUAGE extensions used by modules in this package.
   other-extensions:    BangPatterns, FlexibleInstances, MultiParamTypeClasses, TypeSynonymInstances
-  
+ 
+  other-modules: Config, GeneAlg, Profiling, Result, Rewrite
+
   -- Other library packages from which modules are imported.
 
-  build-depends:       base >=4.7 && <4.8, random >=1.0 && <1.2, GA >=1.0 && <1.1, process >=1.2 && <1.3, bitwise >=0.1 && <0.2, text >=1.2 && <1.3, strict-io >=0.2 && <0.3, deepseq >=1.3 && <1.4, haskell-src-exts >=1.14 && <1.17, directory >=1.2 && <1.3, filepath >=1.3 && <1.4, bv, mtl, uniplate, criterion, parsec, html
+  build-depends:        base >=4.9
+                      , random
+                      , GA
+                      , process
+                      , bitwise
+                      , text
+                      , deepseq
+                      , haskell-src-exts
+                      , directory
+                      , filepath
+                      , bv
+                      , mtl
+                      , uniplate
+                      , criterion
+                      , parsec
+                      , html
+                      , filepath
   
   ghc-options: -O2 -rtsopts "-with-rtsopts=-T"
   -- Directories containing source files.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A tool for inferring strictness annotations in Haskell programs using a genetic 
 ## Build and Run
 
 Autobahn uses [stack](https://github.com/commercialhaskell/stack) to build and run.
+It has been tested with [stack lts-7.2](https://github.com/fpco/lts-haskell/blob/master/lts-7.2.yaml).
 
 Build with
 
@@ -12,21 +13,39 @@ Build with
 > stack init --solver
 > stack setup
 > stack build
+> stack install
 ```
 
 For newer versions of GHC, `stack init` may fail to resolve the necessary packages,
 in which case you will need to initialize with `stack init --solver --install-ghc`.
 
-Then run the executable with
+WARNING: Autobahn will overwrite the original source of your project. You should
+copy or clone your project into a fresh / temporary directory.
+
+Then run the executable with e.g. (assuming `$HOME/.local/bin` is in your PATH):
 
 ```
-> stack exec Autobahn
+> cd test/hello
+> Autobahn
 ```
 
-Autobahn will either take a configuration file or ask the user for inputs on the command line
-to craft a configuration.
+Autobahn takes either a configuration file, named `config.atb` in the present working
+directory, or asks the user for inputs on the command line to craft a configuration
+in the event that `config.atb` is not found.
 
-Currently, Autobahn requires the program builds with cabal.
+### Limitations
+
+Currently,
+
+- Autobahn requires the program builds with cabal.
+- You must specify `ghc-options: -rtsopts "-with-rtsopts=-T"` in your `executable` section.
+- The name of the project and the basename of `main-is` must be the same
+- Any files that Autobahn profiles must already have the `BangPatterns` extension enabled
+  in the `LANGUAGE` section at the top of each file.
+
+See `test/hello` for a minimal example, as taken and modified from
+[http://www.haskell.org/hello/](http://www.haskell.org/hello/). We are working on making
+Autobahn more flexible in terms of the cabal configurations Autobahn will accept.
 
 ### Config File Specification
 

--- a/src/GeneAlg.hs
+++ b/src/GeneAlg.hs
@@ -21,7 +21,12 @@ type BangVec = BV
 type Time = Double
 type Score = Double
 type FitnessRun = [BangVec] -> IO Score
-instance Read BangVec -- TODO is this ok?
+
+-- TODO: implement in case we ever need to parse Bit (Bang) Vectors
+readsBV = undefined
+
+instance Read BangVec where -- TODO is this ok?
+  readsPrec _ s = readsBV
 
 printBits :: [Bool] -> String
 printBits = concatMap (\b -> if b then "1" else "0")

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -53,7 +53,7 @@ fitness projDir args timeLimit reps metric files bangVecs = do
 main :: IO () 
 main = do 
   hSetBuffering stdout LineBuffering
-  print "Configure optimization..."
+  putStrLn "Configure optimization..."
   cfgExist <- doesFileExist cfgFile
   cfg <- if cfgExist then readCfg cfgFile else cliCfg
   putStrLn "Setting up optimization process..."

--- a/src/Rewrite.hs
+++ b/src/Rewrite.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, FlexibleContexts #-}
 
 module Rewrite where
 
@@ -7,7 +7,7 @@ module Rewrite where
 --
 
 import Data.Data
-import Data.Generics.Uniplate.Data
+import Data.Generics.Uniplate.DataOnly
 import Language.Haskell.Exts
 import Control.Monad
 import Control.Monad.State.Strict
@@ -16,10 +16,20 @@ import Control.DeepSeq
 findPats :: Data a => a -> [Pat]
 findPats = universeBi
 
+bangParseMode :: String -> ParseMode
+bangParseMode path = defaultParseMode
+  { parseFilename = path
+  , baseLanguage = Haskell2010
+  , extensions = [EnableExtension BangPatterns]
+  , ignoreLanguagePragmas = False
+  , ignoreLinePragmas = False
+  , fixities = Nothing
+  , ignoreFunctionArity = False
+  }
+
 placesToStrict :: String -> IO Int
 placesToStrict path = do
-  let mode = ParseMode path Haskell2010 [EnableExtension BangPatterns] False False Nothing
-  res <- parseFileWithMode mode path
+  res <- parseFileWithMode (bangParseMode path) path
   case res of
     ParseFailed _ e -> error e
     ParseOk a       -> return $ length $ findPats a
@@ -27,8 +37,7 @@ placesToStrict path = do
 
 readBangs :: String -> IO [Bool]
 readBangs path = do
-  let mode = ParseMode path Haskell2010 [EnableExtension BangPatterns] False False Nothing
-  res <- parseFileWithMode mode path
+  res <- parseFileWithMode (bangParseMode path) path
   case res of
     ParseFailed _ e -> error e
     ParseOk a       -> return $ findBangs $ findPats a
@@ -40,15 +49,15 @@ findBangs = map isBang
 
 editBangs :: String -> [Bool] -> IO String
 editBangs path vec = do
-  let mode = ParseMode path Haskell2010 [EnableExtension BangPatterns] False False Nothing
-  res <- parseFileWithMode mode path
+  res <- parseFileWithMode (bangParseMode path) path
   case res of
     ParseFailed _ e -> error $ path ++ ": " ++ e
     ParseOk a       -> return $ prettyPrint $ stripTop $ fst $ changeBangs vec a
 
 changeBangs :: [Bool] -> Module -> (Module, [Bool])
 changeBangs bools x = runState (transformBiM go x) bools
-  where go pb@(PBangPat p) = do
+  where go :: (MonadState [Bool] m, Uniplate Pat) => Pat -> m Pat
+        go pb@(PBangPat p) = do
            (b:bs) <- get
            put bs
            if b

--- a/test/hello/LICENSE
+++ b/test/hello/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2010, Simon Marlow
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+ 
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND THE CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR THE
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/hello/Setup.hs
+++ b/test/hello/Setup.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMain

--- a/test/hello/config.atb
+++ b/test/hello/config.atb
@@ -1,0 +1,6 @@
+projectDirectory = "/home/karl/w/autobahn/test/hello"
+budgetTime = 0.01h
+coverage = "hello.hs"
+targetMetric = "peakAlloc"
+fitnessRuns = 1
+inputArg = "40"

--- a/test/hello/hello.cabal
+++ b/test/hello/hello.cabal
@@ -1,0 +1,40 @@
+-- Instructions on how to write this file are in the Cabal
+-- documentation, which can be found here:
+--   http://haskell.org/cabal/release/cabal-latest/doc/users-guide/
+
+name: hello
+version: 1.0.0.2
+license: BSD3
+license-file: LICENSE
+copyright: (c) Simon Marlow
+author: Simon Marlow
+maintainer: Simon Marlow <marlowsd@gmail.com>
+bug-reports: mailto:marlowsd@gmail.com
+stability: stable
+homepage: http://www.haskell.org/hello/
+synopsis: Hello World, an example package
+category: Console, Text
+cabal-version: >= 1.6
+build-type: Simple
+
+Description:
+  This is an implementation of the classic "Hello World" program in
+  Haskell, as an example of how to create a minimal Haskell
+  application using Cabal and Hackage.  Please submit any suggestions and
+  improvements.
+
+source-repository head
+  type:     darcs
+  location: http://darcs.haskell.org/hello/
+
+flag threaded
+  default: False
+
+executable hello
+  hs-source-dirs: .
+  main-is: hello.hs
+  build-depends: base >= 4.2 && < 5
+
+  ghc-options: -O2 -rtsopts "-with-rtsopts=-T"
+  if flag(threaded)
+     ghc-options: -threaded

--- a/test/hello/hello.hs
+++ b/test/hello/hello.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE BangPatterns #-}
+module Main (main, fib) where
+import System.Environment
+
+fib 0 = 1
+fib 1 = 1
+fib n = (+) (fib $ n - 1) (fib $ n - 2)
+
+main = do
+  as <- getArgs
+  let a = read $ head as :: Int
+  putStrLn $ show a
+  putStrLn $ show $ fib a
+


### PR DESCRIPTION
NB: The 'hello world' example included here runs forever when I run Autobahn on it, but I'm not sure if this is something I introduced or if it happens with the existing code base too.
- List `other-modules` in cabal as requested by cabal build warning
- Clean-up `build-depends` in cabal to let stack determine compatible
  versions (tested on lts-7.2)
- Readme updates referencing 'hello world' example
- Instance of Read for BangVec needs `readsBV` defined (left undefined
  for now because we don't parse any BangVecs)
- Update for running of Autobahn directly from the project directory
  of interest (since the point of Autobahn is to be a command line tool)
- API update of `uniplate` dependency
- Type signature on `go` in `changeBangs` because of ambiguity error
- `strict-io` is in the cabal file but is not used / is the only dependency which isn't updated to handle ghc 8.0.1.
- Minimal 'hello world' cabal project example

This touches on issues #3 and #12.
