### PR TITLE
Testing infrastructure

### DIFF
--- a/Autobahn.cabal
+++ b/Autobahn.cabal
@@ -78,4 +78,19 @@ executable Autobahn
   
   -- Base language which the package is written in.
   default-language:    Haskell2010
-  
+ 
+test-suite test-autobahn
+  type:           exitcode-stdio-1.0
+  main-is:        test/Test.hs
+  build-depends:  base
+                , process
+                , directory
+                , QuickCheck
+                , HUnit
+                , Cabal
+                , test-framework
+                , test-framework-hunit
+                , test-framework-quickcheck2
+
+  default-language: Haskell2010
+

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,0 +1,55 @@
+module Main where
+import System.Process (system)
+import System.Exit (ExitCode(..))
+import System.Directory
+    ( setCurrentDirectory
+    , getCurrentDirectory
+    , doesDirectoryExist
+    , doesFileExist
+    )
+import Control.Monad (liftM)
+import Data.Monoid
+import Test.Framework
+import Test.Framework.Providers.HUnit
+import Test.Framework.Providers.QuickCheck2
+import Test.HUnit
+import Test.QuickCheck (Property, quickCheck, (==>))
+import qualified Test.QuickCheck.Monadic as TQM
+
+autobahnMe :: FilePath -> [FilePath] -> IO ExitCode
+autobahnMe projDir srcNames = do
+  pwd <- getCurrentDirectory
+  setCurrentDirectory projDir
+  -- Assume the worst - Autobahn was already run and we clobbered the source file:
+  mapM (\s -> system $ "git checkout " ++ s) srcNames
+  system $ "rm -rf autobahn-results autobahn-survivor dist"
+  {- Nesting of calls to stack / cabal doesn't seem to play
+     nicely - need to unset GHC_PACKAGE_PATH as
+     per https://github.com/haskell/cabal/issues/1944 -}
+  rc <- system $ "unset GHC_PACKAGE_PATH && Autobahn"
+  setCurrentDirectory pwd
+  return rc
+
+dirExists = doesDirectoryExist
+fileExists = doesFileExist
+
+helloFib = do
+  let base = "test/hello/"
+  rc <- autobahnMe base ["hello.hs"]
+  assert $ rc == ExitSuccess
+  let results   = base ++ "autobahn-results"
+  let survivor = base ++ "autobahn-survivor"
+  assert $ dirExists results
+  assert $ dirExists survivor
+  assert $ dirExists $ results ++ "/1"
+  assert $ fileExists $ survivor ++ "/hello.hs"
+  assert $ fileExists $ results ++ "/result.html"
+  assert $ fileExists $ results ++ "/1/hello.hs"
+  assert $ liftM not $ fileExists $ base ++ "/timing.temp"
+
+main :: IO ()
+main = defaultMainWithOpts
+  [ testCase "hello" helloFib
+  ] mempty
+
+


### PR DESCRIPTION
Updates to cabal, and inclusion of a `test/Test.hs` module which runs Autobahn and checks the return code as well as whether or not the results and survivor directories exist.

NB: This goes after PR #13 (ghc 8.0.1 update).
